### PR TITLE
fix: custom env prefixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ function getNormalizedOptions(options: PluginOptions) {
  */
 async function validateEnv(userConfig: UserConfig, envConfig: ConfigEnv, options?: PluginOptions) {
   const rootDir = userConfig.root || cwd()
-  const env = loadEnv(envConfig.mode, rootDir)
+  const env = loadEnv(envConfig.mode, rootDir, '')
 
   const isInlineConfig = options !== undefined
   if (!isInlineConfig) {


### PR DESCRIPTION
allow any env prefixes, for fix supporting custom env prefixes
https://vitejs.dev/guide/api-javascript.html#loadenv