### PR TITLE
Fixed issue with optional schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import { cwd } from 'process'
 import path from 'node:path'
-import { type Plugin, loadEnv, normalizePath } from 'vite'
+import { type ConfigEnv, type Plugin, type UserConfig, loadEnv, normalizePath } from 'vite'
 import { createConfigLoader as createLoader } from 'unconfig'
 import { builtinValidation } from './validators/builtin'
 import { zodValidation } from './validators/zod'
 import type { FullPluginOptions, PluginOptions, Schema } from './contracts'
-import type { ConfigEnv, UserConfig } from 'vite'
 
 /**
  * Load schema defined in `env.ts` file using unconfig

--- a/src/validators/builtin/index.ts
+++ b/src/validators/builtin/index.ts
@@ -24,6 +24,13 @@ export function builtinValidation(env: Record<string, string>, schema: PoppinsSc
   for (const [key, validator] of Object.entries(schema!)) {
     try {
       const res = validator(key, env[key])
+
+      // Handle undefined aka optional results
+      if (typeof res === 'undefined') {
+        delete process.env[key]
+        return
+      }
+
       process.env[key] = res
     } catch (err) {
       errors.push({ key, err })

--- a/src/validators/zod/index.ts
+++ b/src/validators/zod/index.ts
@@ -29,6 +29,12 @@ export async function zodValidation(env: Record<string, string>, schema: ZodSche
       continue
     }
 
+    // Handle undefined aka optional results
+    if (typeof result.data === 'undefined') {
+      delete process.env[key]
+      return
+    }
+
     process.env[key] = result.data
   }
 

--- a/tests/common.spec.ts
+++ b/tests/common.spec.ts
@@ -167,4 +167,28 @@ test.group('vite-plugin-validate-env', (group) => {
       assert.include(error.message, 'Missing environment variable "VITE_TEST2"')
     }
   })
+
+  test('Optional Variables', async ({ assert }) => {
+    // assert.plan(2);
+
+    const plugin = ValidateEnv({ VITE_OPTIONAL: Schema.number.optional() })
+
+    // Test with the variable set, but invalid
+    await fs.add('.env.development', 'VITE_OPTIONAL=not a number')
+    try {
+      // @ts-ignore
+      await plugin.config(viteConfig, viteEnvConfig)
+    } catch (error: any) {
+      assert.include(
+        error.message,
+        'Value for environment variable "VITE_OPTIONAL" must be numeric, instead received'
+      )
+    }
+
+    // Test without variable
+    await fs.add('.env.development', '')
+    // @ts-ignore
+    await plugin.config(viteConfig, viteEnvConfig)
+    assert.equal(process.env.VITE_OPTIONAL, undefined)
+  })
 })


### PR DESCRIPTION
When a Schema, either built-in or via zod has an optional variable, which results in the validation result being undefined, the corresponding env-variable is set to 'undefined', because of the implicit string conversion via process.env.
This however does not match the types generated for the `import.meta.env` and is, at least imo, not what I'd expect to happen.

This PR fixes that issue, by unsetting any env-variable, which is `undefined` after validation and adds tests for this case.
I adapted the test-files slightly to fix any eslint/prettier warnings as well, but we can roll this back again :)