### PR TITLE
fix: show zod default values

### DIFF
--- a/src/utils/cliui.ts
+++ b/src/utils/cliui.ts
@@ -1,3 +1,7 @@
 import { cliui } from '@poppinss/cliui'
 
-export const ui = cliui({ mode: process.env.NODE_ENV === 'testing' ? 'raw' : 'normal' })
+export type UI = ReturnType<typeof initUi>
+
+export function initUi() {
+  return cliui({ mode: process.env.NODE_ENV === 'testing' ? 'raw' : 'normal' })
+}

--- a/src/validators/builtin/index.ts
+++ b/src/validators/builtin/index.ts
@@ -1,7 +1,7 @@
-import { ui } from '../../utils/cliui.js'
+import type { UI } from '../../utils/cliui.js'
 import type { PoppinsSchema } from '../../contracts/index.js'
 
-export function errorReporter(errors: any[]) {
+export function errorReporter(ui: UI, errors: any[]) {
   let finalMessage = ui.colors.red('Failed to validate environment variables : \n')
 
   for (const error of errors) {
@@ -18,7 +18,7 @@ export function errorReporter(errors: any[]) {
 /**
  * Validate the env values with builtin validator
  */
-export function builtinValidation(env: Record<string, string>, schema: PoppinsSchema) {
+export function builtinValidation(ui: UI, env: Record<string, string>, schema: PoppinsSchema) {
   const errors = []
   const variables = []
 
@@ -36,7 +36,7 @@ export function builtinValidation(env: Record<string, string>, schema: PoppinsSc
   }
 
   if (errors.length) {
-    throw new Error(errorReporter(errors))
+    throw new Error(errorReporter(ui, errors))
   }
 
   return variables

--- a/src/validators/zod/index.ts
+++ b/src/validators/zod/index.ts
@@ -1,8 +1,8 @@
 import type { ZodSchema } from 'zod'
 
-import { ui } from '../../utils/cliui.js'
+import type { UI } from '../../utils/cliui.js'
 
-export function errorReporter(errors: any[]) {
+export function errorReporter(ui: UI, errors: any[]) {
   let finalMessage = ui.colors.red('Failed to validate environment variables : \n')
 
   for (const error of errors) {
@@ -19,7 +19,7 @@ export function errorReporter(errors: any[]) {
 /**
  * Validate the env values with Zod validator
  */
-export async function zodValidation(env: Record<string, string>, schema: ZodSchema) {
+export async function zodValidation(ui: UI, env: Record<string, string>, schema: ZodSchema) {
   const errors = []
   const variables = []
 
@@ -38,7 +38,7 @@ export async function zodValidation(env: Record<string, string>, schema: ZodSche
   }
 
   if (errors.length) {
-    throw new Error(errorReporter(errors))
+    throw new Error(errorReporter(ui, errors))
   }
 
   return variables

--- a/tests/common.spec.ts
+++ b/tests/common.spec.ts
@@ -1,9 +1,13 @@
 import { test } from '@japa/runner'
 
-import { ui } from '../src/utils/cliui.js'
-import { Schema, ValidateEnv } from '../src/index.js'
+import type { UI } from '../src/utils/cliui.js'
+import { Schema, ValidateEnv as CoreTypedValidateEnv } from '../src/index.js'
 
 const viteEnvConfig = { mode: 'development', command: 'serve' } as const
+
+const ValidateEnv = CoreTypedValidateEnv as (
+  ...args: Parameters<typeof CoreTypedValidateEnv>
+) => ReturnType<typeof CoreTypedValidateEnv> & { ui: UI }
 
 test.group('vite-plugin-validate-env', () => {
   test('Basic validation', async ({ assert, fs }) => {
@@ -246,7 +250,7 @@ test.group('vite-plugin-validate-env', () => {
     // @ts-ignore
     await plugin.config({ root: fs.basePath }, viteEnvConfig)
 
-    const logs = ui.logger.getLogs()
+    const logs = plugin.ui.logger.getLogs()
     assert.deepEqual(logs[0].message, 'cyan([vite-plugin-validate-env]) debug process.env content')
     assert.deepInclude(logs[1].message, 'cyan(VITE_BOOLEAN): true')
   })
@@ -267,7 +271,7 @@ test.group('vite-plugin-validate-env', () => {
       assert.include(error.message, 'Value for environment variable "VITE_TESTX" must be a boolean')
     }
 
-    const logs = ui.logger.getLogs()
+    const logs = plugin.ui.logger.getLogs()
     const messages = logs.map((log) => log.message)
     assert.isDefined(
       messages.find(


### PR DESCRIPTION
If a zod value is defaulted we should show the default, not `undefined`.

This also fixes the tests so that the logs do not bleed into other tests causing false results. I would have liked to change this to a class to avoid having to pass the UI argument around but didn't think it'd make that much difference to the code and it'd be more changes than just the bugfix.

This is a followup to https://github.com/Julien-R44/vite-plugin-validate-env/pull/14