### PR TITLE
fix: add vite 6+ to supported list of vite versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "checks": "pnpm lint && pnpm typecheck"
   },
   "peerDependencies": {
-    "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0",
+    "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "zod": "^3.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
While overriding also works I guess adding the v6 as supported version is better for everyone. Thanks in advance! :slightly_smiling_face: 