### PR TITLE
docs: fix missing validator and schema in env.ts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ export default defineConfig({
 import { defineConfig, Schema } from '@julr/vite-plugin-validate-env'
 
 export default defineConfig({
-  VITE_MY_VAR: Schema.enum(['foo', 'bar'] as const),
+  validator: "builtin",
+  schema: {
+    VITE_MY_VAR: Schema.enum(['foo', 'bar'] as const),
+  },
 })
 ```
 


### PR DESCRIPTION
Fix documentation error in the "Using a Dedicated env.ts Config File" section where the example was missing the required `validator` and `schema` properties.

Without these properties, the plugin throws an error: "validator is not a function"

The corrected example now includes:
- validator: "builtin" property
- schema object wrapping the environment variable definitions

This ensures the example works correctly when copied from the documentation.