### PR TITLE
docs: fix TypeScript declaration filename to match Vite conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ export default defineConfig({
 ## Typing `import.meta.env`
 
 In order to have a type-safe `import.meta.env`, the ideal is to use the dedicated configuration file `env.ts`.
-Once this is done, you would only need to add an `env.d.ts` in `src/` folder to augment `ImportMetaEnv` (as [suggested here](https://vitejs.dev/guide/env-and-mode.html#env-files) ) with the following content:
+Once this is done, you would only need to add an `vite-env.d.ts` in `src/` folder to augment `ImportMetaEnv` (as [suggested here](https://vitejs.dev/guide/env-and-mode.html#env-files) ) with the following content:
 
 ```ts
 /// <reference types="vite/client" />


### PR DESCRIPTION
Fix documentation to use vite-env.d.ts instead of env.d.ts for TypeScript declarations.  According to Vite's official documentation (https://vite.dev/guide/env-and-mode.html#intellisense-for-typescript),  the file must be named vite-env.d.ts for TypeScript IntelliSense to work properly. Using env.d.ts will not  be recognized by Vite's built-in type system and IntelliSense features will not function correctly.